### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Links
 .. _MIT license: http://opensource.org/licenses/MIT
 .. _build status: https://travis-ci.org/waveform80/compoundfiles
 
-.. |pypi| image:: https://pypip.in/version/compoundfiles/badge.svg
+.. |pypi| image:: https://img.shields.io/pypi/v/compoundfiles.svg
     :target: https://pypi.python.org/pypi/compoundfiles
     :alt: Latest release
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20compoundfiles))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `compoundfiles`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.